### PR TITLE
update intro-intermediate landing pages

### DIFF
--- a/intermediate/_site.yml
+++ b/intermediate/_site.yml
@@ -3,7 +3,7 @@ title: "R for Water Resources Data Science"
 description: |
   R for Water Resources Data Science
 output_dir: "."
-# repository_url: https://github.com/ryanpeek/WRDS_intro/ # works with source_url
+repository_url: https://github.com/ryanpeek/r4wrds
 include: [".nojekyll"]
 navbar:
   title: "R4WRDS Intermediate Course"

--- a/intermediate/index.Rmd
+++ b/intermediate/index.Rmd
@@ -27,16 +27,16 @@ What makes an *Intermediate `R` user*? This course is most relevant and targeted
 
 ## What will you learn?
 
-In this course, we will move more quickly, assume familiarity with basic `R` skills, and also assume that the participant has experience with more complex workflows, operations, and code-bases. Each module in this course functions as a "stand-alone" lesson, and can be read linearly, or out of order according to your needs and interests. Each module doesn't necessarily require familiarity with the previous module.
+In this course, we will move more quickly, assume familiarity with basic `R` skills, and also assume that the participant has working experience with more complex workflows, operations, and code-bases. Each module in this course functions as a "stand-alone" lesson, and can be read linearly, or out of order according to your needs and interests. Each module doesn't necessarily require familiarity with the previous module.
 
 **This course emphasizes:**
 
- - Intermediate scripting skills like iteration, functional programming, writing functions, and controlling project workflows for better reproducibility and efficiency.
- - Approaches to working with more complex data structures like lists and timeseries data.
- - The fundamentals of building Shiny Apps.
- - Pulling water resources data from APIs.
- - Intermediate mapmaking and spatial data processing.
- - Integrating version control in projects with git.
+ - Intermediate scripting skills like iteration, functional programming, writing functions, and controlling project workflows for better reproducibility and efficiency
+ - Approaches to working with more complex data structures like lists and timeseries data
+ - The fundamentals of building Shiny Apps
+ - Pulling water resources data from APIs
+ - Intermediate mapmaking and spatial data processing
+ - Integrating version control in projects with git
 
 
 (ref:AHRemoteR) *Artwork by @allison_horst*
@@ -50,8 +50,6 @@ knitr::include_graphics(path = "https://raw.githubusercontent.com/allisonhorst/s
 :::obj
 
 **Course Modules**
-
-In this course, we will:
 
 1. [Check/Update R/RStudio and Packages](m_updating_r.html)  
 3. [Version Control with git](m_version_control.html) 
@@ -69,7 +67,7 @@ In this course, we will:
 
 ## Why `R`?
 
-[`R`](https://www.r-project.org/) is an open-source language for statistical computing and a general purpose programming language. It is one of the primary languages used for data science, modeling, and visualization. 
+[`R`](https://www.r-project.org/) is an open-source language for statistical computing and a general purpose programming language. It is one of the primary languages used for data science, modeling, and visualization.  
 
 <br>
 
@@ -82,13 +80,22 @@ We will follow the [SFS Code of Conduct](https://freshwater-science.org/about/so
 
 ## Source content
 
-All source materials for this website can be accessed at **[final GH location, perhaps CAOpenWater/wrds]**.
+All source materials for this website can be accessed at the [`r4wrds` Github repository](https://github.com/ryanpeek/r4wrds).  
+
+<br>
+
+## Data
+
+All data used in this course is expected to live in a `/data` subfolder in the project directory. It can be downloaded in 1 of 2 ways:
+
+1. [Downloaded and unzipped from OSF](link-needed)  
+2. [Cloned from the `wrds-data` Github repository](https://github.com/richpauloo/r4wrds-data)  
 
 <br>
 
 ## Attribution
 
-Content in these lessons has been modified and/or adapted from [Data Carpentry: R for data analysis and visualization of Ecological Data](https://datacarpentry.org/R-ecology-lesson/index.html), the USGS-R training curriculum [here](https://github.com/USGS-R/training-curriculum), the NCEAS Open Science for Synthesis workshop [here](https://nceas.github.io/oss-2017/index.html), [Mapping in R](https://ryanpeek.org/mapping-in-R-workshop/), and the wonderful text [R for data science](https://github.com/hadley/r4ds).
+Content in these lessons has been modified and/or adapted from [Data Carpentry: `R` for data analysis and visualization of Ecological Data](https://datacarpentry.org/R-ecology-lesson/index.html), the USGS-R training curriculum [here](https://github.com/USGS-R/training-curriculum), the NCEAS Open Science for Synthesis workshop [here](https://nceas.github.io/oss-2017/index.html), [Mapping in `R`](https://ryanpeek.org/mapping-in-R-workshop/), and the wonderful text [`R` for data science](https://github.com/hadley/r4ds).
 
 <br>
 

--- a/intermediate/index.Rmd
+++ b/intermediate/index.Rmd
@@ -1,5 +1,5 @@
 ---
-title: "Welcome!"
+title: "R4WRDS Intermediate Course"
 description: |
   Increasing your efficiency with reproducible workflows in R
 site: distill::distill_website

--- a/intermediate/styles.css
+++ b/intermediate/styles.css
@@ -238,3 +238,26 @@ css below is adapted from that page */
   background-color:#f4f4f4;
   border-radius: 4px;
 }
+
+
+/*make the link in the appendix more readable against the grey text*/
+d-appendix a:link {
+  color: blue;
+  background-color: transparent;
+  text-decoration: none;
+}
+d-appendix a:visited {
+  color: lightblue;
+  background-color: transparent;
+  text-decoration: none;
+}
+d-appendix a:hover {
+  color: lightblue;
+  background-color: transparent;
+  text-decoration: underline;
+}
+d-appendix a:active {
+  color: blue;
+  background-color: transparent;
+  text-decoration: underline;
+}

--- a/intro/_site.yml
+++ b/intro/_site.yml
@@ -3,7 +3,7 @@ title: "R for Water Resources Data Science"
 description: |
   R for Water Resources Data Science
 output_dir: "."
-# repository_url: https://github.com/ryanpeek/WRDS_intro/ # works with source_url
+repository_url: https://github.com/ryanpeek/r4wrds # works with source_url
 include: [".nojekyll"]
 navbar:
   title: "R4WRDS Introductory Course"

--- a/intro/index.Rmd
+++ b/intro/index.Rmd
@@ -17,7 +17,26 @@ knitr::opts_chunk$set(echo = TRUE)
 <br>
 
 
-# Welcome to the R4WRDS Introductory Course!
+## Who is this course for?
+
+This course is most relevant and targeted at folks who work with data, from analysts and program staff to engineers and scientists. This course is designed as an introduction to the power and possibility that a reproducible programming language (R) provides by demonstrating how to import, explore, visualize, and communicate different types of data. Using water resources based examples, this course will guide participants through basic data science skills and strategies for continued learning and use of R
+
+## What will you learn?
+
+In this course, we will start from the ground up, and while each module in this course functions as a "stand-alone" lesson, following modules in progression is recommended.
+
+**In this course you will gain practice in: **
+
+ - Data and file management: understanding RProjects and file paths
+ - Understand and identifying different data formats (i.e., wide, long, tidy)
+ - Working with different data structures (i.e., vectors, dataframes, lists) 
+ - Import and export various water resources data
+ - Strategies for Exploratory Data Analysis (EDA)
+ - Strategies for troubleshooting (reading documentation, intro to reprex)
+ - Transforming data with `{dplyr}`
+ - Data visualization with `{ggplot2}`
+ - Data presentation and communication with RMarkdown
+
 
 (ref:AHRemoteR) *Artwork by @allison_horst*
 

--- a/intro/index.Rmd
+++ b/intro/index.Rmd
@@ -19,18 +19,18 @@ knitr::opts_chunk$set(echo = TRUE)
 
 ## Who is this course for?
 
-This course is most relevant and targeted at folks who work with data, from analysts and program staff to engineers and scientists. This course is designed as an introduction to the power and possibility that a reproducible programming language (R) provides by demonstrating how to import, explore, visualize, and communicate different types of data. Using water resources based examples, this course will guide participants through basic data science skills and strategies for continued learning and use of R
+This course is most relevant and targeted at folks who work with data, from analysts and program staff to engineers and scientists. This course provides an introduction to the power and possibility of a reproducible programming language (`R`) by demonstrating how to import, explore, visualize, analyze, and communicate different types of data. Using water resources based examples, this course guides participants through basic data science skills and strategies for continued learning and use of `R`.
 
 ## What will you learn?
 
-In this course, we will start from the ground up, and while each module in this course functions as a "stand-alone" lesson, following modules in progression is recommended.
+In this course, we start from first principles and assume no prior experience with `R`. Although each module in this course can serve as a "stand-alone" lesson, we recommend completing modules in order from start to finish.
 
 **In this course you will gain practice in: **
 
  - Data and file management: understanding RProjects and file paths
  - Understand and identifying different data formats (i.e., wide, long, tidy)
  - Working with different data structures (i.e., vectors, dataframes, lists) 
- - Import and export various water resources data
+ - Importing and exporting various water resources data
  - Strategies for Exploratory Data Analysis (EDA)
  - Strategies for troubleshooting (reading documentation, intro to reprex)
  - Transforming data with `{dplyr}`
@@ -49,8 +49,6 @@ knitr::include_graphics(path = "https://raw.githubusercontent.com/allisonhorst/s
 :::obj
 
 **Course Modules**
-
-In this course, we will:
 
 1. [Install R and RStudio](m_install_R.html)  
 2. [Get oriented in RStudio](m_getting_started.html)  
@@ -72,7 +70,11 @@ In this course, we will:
 
 <br>
 
-[R](https://www.r-project.org/) is a language for statistical computing as well as a general purpose programming language. Increasingly, it has become one of the primary languages used in data science for data analysis, modeling, and visualization. This workshop will provide attendees with a starting point for continued learning and use of R. We will cover a variety of commonly used file types (i.e., `.csv`, `.xlsx`, `.shp`) used in analysis, and provide resources for additional learning.
+## Why `R`?
+
+[`R`](https://www.r-project.org/) is a language for statistical computing and a general purpose programming language. It is one of the primary languages used for data science, modeling, and visualization. 
+
+This workshop will provide attendees with a starting point for continued learning and use of `R`. We will cover a variety of commonly used file types (i.e., `.csv`, `.xlsx`, `.shp`) used in analysis, and provide resources for additional learning.
 
 <br>
 
@@ -85,13 +87,22 @@ We will follow the [SFS Code of Conduct](https://freshwater-science.org/about/so
 
 ## Source content
 
-All source materials for this website can be accessed at **[final GH location, perhaps CAOpenWater/wrds]**.
+All source materials for this website can be accessed at the [`r4wrds` Github repository](https://github.com/ryanpeek/r4wrds).  
+
+<br>
+
+## Data
+
+All data used in this course is expected to live in a `/data` subfolder in the project directory. It can be downloaded in 1 of 2 ways:
+
+1. [Downloaded and unzipped from OSF](link-needed)  
+2. [Cloned from the `wrds-data` Github repository](https://github.com/richpauloo/r4wrds-data)  
 
 <br>
 
 ## Attribution
 
-Content in these lessons has been modified and/or adapted from [Data Carpentry: R for data analysis and visualization of Ecological Data](https://datacarpentry.org/R-ecology-lesson/index.html), the USGS-R training curriculum [here](https://github.com/USGS-R/training-curriculum), the NCEAS Open Science for Synthesis workshop [here](https://nceas.github.io/oss-2017/index.html), [Mapping in R](https://ryanpeek.org/mapping-in-R-workshop/), and the wonderful text [R for data science](https://github.com/hadley/r4ds).
+Content in these lessons has been modified and/or adapted from [Data Carpentry: `R` for data analysis and visualization of Ecological Data](https://datacarpentry.org/R-ecology-lesson/index.html), the USGS-R training curriculum [here](https://github.com/USGS-R/training-curriculum), the NCEAS Open Science for Synthesis workshop [here](https://nceas.github.io/oss-2017/index.html), [Mapping in `R`](https://ryanpeek.org/mapping-in-R-workshop/), and the wonderful text [`R` for data science](https://github.com/hadley/r4ds).
 
 
 <br> 

--- a/intro/styles.css
+++ b/intro/styles.css
@@ -228,3 +228,26 @@ css below is adapted from that page */
   background-color:#f4f4f4;
   border-radius: 4px;
 }
+
+
+/*make the link in the appendix more readable against the grey text*/
+d-appendix a:link {
+  color: blue;
+  background-color: transparent;
+  text-decoration: none;
+}
+d-appendix a:visited {
+  color: lightblue;
+  background-color: transparent;
+  text-decoration: none;
+}
+d-appendix a:hover {
+  color: lightblue;
+  background-color: transparent;
+  text-decoration: underline;
+}
+d-appendix a:active {
+  color: blue;
+  background-color: transparent;
+  text-decoration: underline;
+}


### PR DESCRIPTION
this updates the home pages for each of the intro and intermediate so they have the same info/title standards.

This also adds a minor change to each of the intro and intermediate `_site.yml` files to add the option to file an issues if folks find errors (or we do!) or make comments on pages. I think it should work (see line 6 in the `_site.yml` files).